### PR TITLE
Fixed .gitignore again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,20 @@
 !/settings.gradle
 !/gradle.properties
 !/gradlew*
+!/gradle
 
 # checkstyle
 !/checkstyle*.xml
 
 # Travis
 !/.travis.yml
+
+# unwanted os-generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+*~


### PR DESCRIPTION
`/gradle` is the folder, it's already in the repo so I assume we want it in there
@Kubuxu The unwanted files need to be there, we are blacklisting anything in the _repo root_ by default, not _any file in general_.