### PR TITLE
Added the dependency generation

### DIFF
--- a/src/main/java/nova/core/deps/DependencyRepoProvider.java
+++ b/src/main/java/nova/core/deps/DependencyRepoProvider.java
@@ -1,0 +1,20 @@
+package nova.core.deps;
+
+/**
+ * The interface NOVA mods that want to provide repos to download from should use.
+ *
+ * Not required. If not used, it will continue on and not generate dependencies.
+ *
+ * @author Mitchellbrine
+ */
+public interface DependencyRepoProvider {
+
+	/**
+	 * The method for determining the repo(s) for a certain dependency
+	 *
+	 * @param mod - The modid of the dependency. You can check this in any way you want.
+	 * @return - the list of repos for the dependency
+	 */
+	String[] getModRepo(String mod);
+
+}


### PR DESCRIPTION
This system allows for mods to specify which dependencies have repos and include mirrors in case some are down.

(If we need to, I can add in a way for the core to include the downloading and the wrapper to specify the location in which to download to)