### PR TITLE
Added vital maps for checking ids and versions

### DIFF
--- a/src/main/java/nova/core/deps/DepDownloader.java
+++ b/src/main/java/nova/core/deps/DepDownloader.java
@@ -1,0 +1,38 @@
+package nova.core.deps;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+
+/**
+ * Created by Mitchellbrine on 2015.
+ */
+public abstract class DepDownloader {
+
+	public void downloadDepdency(URL versionURL, String locationToDownloadTo) {
+		try {
+
+			InputStream stream = versionURL.openStream();
+
+			File dependencyLocation = new File(locationToDownloadTo);
+
+			byte[] buffer = new byte[4096];
+			int n = - 1;
+
+			OutputStream output = new FileOutputStream(dependencyLocation);
+			while ( (n = stream.read(buffer)) != -1)
+			{
+				output.write(buffer, 0, n);
+			}
+			output.close();
+			stream.close();
+
+		} catch (IOException ex) {
+			ex.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
It should now have a version for each mod id that the wrapper should get. This should allow for checking that a certain repository matches that of a mod id and use that to get the file.

(The implementation should now be a lot cleaner in the wrapper)