### PR TITLE
Changes to Matrix equality

### DIFF
--- a/src/main/java/nova/core/util/transform/Matrix.java
+++ b/src/main/java/nova/core/util/transform/Matrix.java
@@ -330,13 +330,13 @@ public class Matrix extends Operator<Matrix, Matrix> implements Cloneable, Trans
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof Matrix) {
+		if (obj.getClass() == this.getClass()) {
 			Matrix B = (Matrix) obj;
 			Matrix A = this;
 			if (B.rows == A.rows && B.columns == A.columns) {
 				for (int i = 0; i < rows; i++)
 					for (int j = 0; j < columns; j++)
-						if (!DoubleMath.fuzzyEquals(A.mat[i][j], B.mat[i][j],0.00001)) {
+						if (A.mat[i][j] != B.mat[i][j]) {
 							return false;
 						}
 				return true;

--- a/src/main/java/nova/core/util/transform/Matrix.java
+++ b/src/main/java/nova/core/util/transform/Matrix.java
@@ -325,7 +325,7 @@ public class Matrix extends Operator<Matrix, Matrix> implements Cloneable, Trans
 	}
 
 	public boolean fuzzyEquals(Matrix B) {
-		return fuzzyEquals(B, 0.00001);
+		return fuzzyEquals(B, 0.0000001);
 	}
 
 	@Override
@@ -382,13 +382,17 @@ public class Matrix extends Operator<Matrix, Matrix> implements Cloneable, Trans
 		return new Vector3d(x / w, y / w, z / w);
 	}
 
-	public boolean isAlmostZero() {
+	public boolean isAlmostZero(double tolerance) {
 		for (int i = 0; i < rows; i++)
 			for (int j = 0; j < columns; j++)
-				if (mat[i][j] > 0.0000001) {
+				if (Math.abs(mat[i][j]) > tolerance) {
 					return false;
 				}
 		return true;
+	}
+	
+	public boolean isAlmostZero() {
+		return isAlmostZero(0.0000001);
 	}
 
 	@Override

--- a/src/main/java/nova/core/util/transform/Matrix.java
+++ b/src/main/java/nova/core/util/transform/Matrix.java
@@ -304,6 +304,30 @@ public class Matrix extends Operator<Matrix, Matrix> implements Cloneable, Trans
 
 	}
 
+	/**
+	 * Compares two matrices with an error tolerance.
+	 * 
+	 * @param B the matrix to compare to
+	 * @param tolerance the error tolerance
+	 * @return true if the matrix components are within {@code tolerance} of each other
+	 */
+	public boolean fuzzyEquals(Matrix B, double tolerance) {
+		Matrix A = this;
+		if (B.rows == A.rows && B.columns == A.columns) {
+			for (int i = 0; i < rows; i++)
+				for (int j = 0; j < columns; j++)
+					if (!DoubleMath.fuzzyEquals(A.mat[i][j], B.mat[i][j], tolerance)) {
+						return false;
+					}
+			return true;
+		}
+		return false;
+	}
+
+	public boolean fuzzyEquals(Matrix B) {
+		return fuzzyEquals(B, 0.00001);
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof Matrix) {

--- a/src/test/java/nova/core/util/transform/Matrix4x4Test.java
+++ b/src/test/java/nova/core/util/transform/Matrix4x4Test.java
@@ -86,6 +86,7 @@ public class Matrix4x4Test {
 	public void testIllegalArgument2() {
 		new Matrix4x4(new double[][]{{1,1},{1,1},{1,1},{1,1}});
 	}
+
 	@Test
 	public void testEquals() {
 		double[][] start = {
@@ -96,8 +97,11 @@ public class Matrix4x4Test {
 		Matrix4x4 firstMatrix = new Matrix4x4(start);
 		start[2][3] = 17;
 		Matrix4x4 secondMatrix = new Matrix4x4(start);
+		Matrix thirdMatrix = new Matrix(start);
 		assertFalse(firstMatrix.equals(secondMatrix));
 		assertTrue(firstMatrix.equals(firstMatrix));
 		assertFalse(firstMatrix.equals("test"));
+		assertFalse(thirdMatrix.equals(secondMatrix));
+		assertTrue(thirdMatrix.fuzzyEquals(secondMatrix, 0.0));
 	}
 }

--- a/src/test/java/nova/core/util/transform/MatrixTest.java
+++ b/src/test/java/nova/core/util/transform/MatrixTest.java
@@ -1,5 +1,7 @@
 package nova.core.util.transform;
 
+import nova.core.util.transform.Matrix;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -272,5 +274,17 @@ public class MatrixTest {
 		assertTrue(firstMatrix.fuzzyEquals(secondMatrix));
 		assertFalse(firstMatrix.fuzzyEquals(thirdMatrix));
 		assertFalse(firstMatrix.equals(secondMatrix));
+	}
+
+	@Test
+	public void testIsAlmostZero() {
+		double[][] start = {
+			{ 0, -0.00000001, 0 },
+			{ 0, 0, 0.000000001 } };
+		Matrix firstMatrix = new Matrix(start);
+		start[0][0] = -0.01;
+		Matrix secondMatrix = new Matrix(start);
+		assertTrue(firstMatrix.isAlmostZero());
+		assertFalse(secondMatrix.isAlmostZero());
 	}
 }

--- a/src/test/java/nova/core/util/transform/MatrixTest.java
+++ b/src/test/java/nova/core/util/transform/MatrixTest.java
@@ -257,4 +257,20 @@ public class MatrixTest {
 		assertTrue(firstMatrix.equals(firstMatrix));
 		assertFalse(firstMatrix.equals("test"));
 	}
+	
+	@Test
+	public void testFuzzyEquals() {
+		double[][] start = {
+			{ 1, 2, 3 },
+			{ 5, 6, 7 },
+			{ 8, 0, 1 } };
+		Matrix firstMatrix = new Matrix(start);
+		start[1][2] += 0.0000001;
+		Matrix secondMatrix = new Matrix(start);
+		start[0][1] += 0.001;
+		Matrix thirdMatrix = new Matrix(start);
+		assertTrue(firstMatrix.fuzzyEquals(secondMatrix));
+		assertFalse(firstMatrix.fuzzyEquals(thirdMatrix));
+		assertFalse(firstMatrix.equals(secondMatrix));
+	}
 }

--- a/src/test/java/nova/core/util/transform/MatrixTest.java
+++ b/src/test/java/nova/core/util/transform/MatrixTest.java
@@ -271,7 +271,7 @@ public class MatrixTest {
 		Matrix secondMatrix = new Matrix(start);
 		start[0][1] += 0.001;
 		Matrix thirdMatrix = new Matrix(start);
-		assertTrue(firstMatrix.fuzzyEquals(secondMatrix));
+		assertTrue(firstMatrix.fuzzyEquals(secondMatrix, 0.00001));
 		assertFalse(firstMatrix.fuzzyEquals(thirdMatrix));
 		assertFalse(firstMatrix.equals(secondMatrix));
 	}

--- a/src/test/java/nova/core/util/transform/MatrixTest.java
+++ b/src/test/java/nova/core/util/transform/MatrixTest.java
@@ -102,10 +102,10 @@ public class MatrixTest {
 				{ -5, 0 } }
 		);
 
-		assertEquals(start.rref(), Matrix.identity(2));
+		assertTrue(start.rref().fuzzyEquals(Matrix.identity(2)));
 
 		start = new Matrix(new double[][]{{0,3,4},{5,2,3},{1,5,1}});
-		assertEquals(start.rref(), Matrix.identity(3));
+		assertTrue(start.rref().fuzzyEquals(Matrix.identity(3)));
 	}
 
 	@Test
@@ -122,7 +122,7 @@ public class MatrixTest {
 		);
 
 		Matrix reciprocal = start.reciprocal();
-		assertTrue(inverse.subtract(reciprocal).isAlmostZero());
+		assertTrue(reciprocal.fuzzyEquals(inverse));
 	}
 
 /*	@Test
@@ -159,7 +159,7 @@ public class MatrixTest {
 			{ 1 },
 			{ -2 }
 		});
-		assertTrue(x.subtract(expectedX).isAlmostZero());
+		assertTrue(x.fuzzyEquals(expectedX));
 	}
 
 	@Test


### PR DESCRIPTION
The equals method of Matrix should perform an exact comparison, otherwise it will not work correctly with hashCode.
Instead, for inexact comparison, fuzzyEquals can be used.